### PR TITLE
Converted to Control.Lens

### DIFF
--- a/codo-notation.cabal
+++ b/codo-notation.cabal
@@ -1,5 +1,5 @@
 name:                codo-notation
-version:             0.5.2
+version:             0.6
 synopsis:            A notation for comonads, analogous to the do-notation for monads.
 description:         A notation for comonads, analogous to the do-notation for monads. 
 		     .
@@ -62,5 +62,5 @@ library
                        template-haskell >= 2.7,
                        haskell-src-meta >= 0.5.1,
                        parsec >= 3,
-                       uniplate >= 1.6
+                       lens >= 3.0 && < 3.6
   hs-source-dirs:      src


### PR DESCRIPTION
I put together a patch to use the `lens` library's considerably faster version of Uniplate that you might consider.

The major advantages over the original `uniplate` package are that:
- You can use the same combinators with `uniplate` that you can use with any other `Traversal`.
- You don't have to worry about linking a module that happens to use the `Data` `Uniplate` instances or happens to use a hand-rolled uniplate instance, which then infects everything else.
- It is about 45% faster.
- It doesn't repeat the same code 4 times throughout the package.
- It already uses comonads internally. ;)

None of these are particularly compelling, in isolation, but the API remains the same. 

(If I add an instance of `Plated` to `Exp` then other than imports your code wouldn't change at all.)
