### PR TITLE
Add Unicode alternative for =>

### DIFF
--- a/src/Language/Haskell/Codo.lhs
+++ b/src/Language/Haskell/Codo.lhs
@@ -90,7 +90,7 @@ core operations of the comonad
 
 > -- Parsing a codo-block
 
-> pattern  = (try ( do string "=>"
+> pattern  = (try ( do string "=>" <|> string "⇒"
 >                      return "" )) <|>
 >                ( do p <- anyChar
 >                     ps <- pattern


### PR DESCRIPTION
Bindings in codo blocks already work with the Unicode arrow `←` if UnicodeSyntax is enabled, but this looks a bit silly when the block is initiated by `=>`. This adds `⇒` as an alternative to `=>`.
