### PR TITLE
Support ViewPatterns in codo bindings.

### DIFF
--- a/codo-notation.cabal
+++ b/codo-notation.cabal
@@ -61,6 +61,7 @@ library
                        comonad >= 3,
                        template-haskell >= 2.7,
                        haskell-src-meta >= 0.5.1,
+                       haskell-src-exts >= 1.16,
                        parsec >= 3,
                        lens >= 3.0
   hs-source-dirs:      src


### PR DESCRIPTION
While I don’t really grok comonads or codo notation, I was shily experimenting with them a bit, when it occurred to me that ViewPatterns might be useful to have. So I took a stab at adding support for ViewPatterns in codo bindings. It might be hackier than desirable, but I tought I’d ping you just in case you might deem it useful.
