### PR TITLE
Updated to work with current version of GHC. Reduced warnings.

### DIFF
--- a/src/Language/Haskell/Codo.lhs
+++ b/src/Language/Haskell/Codo.lhs
@@ -4,9 +4,6 @@
 > module Language.Haskell.Codo(codo,context,coextendR) where -- coextendR is only exported at the moment for illustration purposes but later should be hidden
 
 > import Text.ParserCombinators.Parsec
-> import Text.ParserCombinators.Parsec.Expr
-> import Text.Parsec.Char
-> import qualified Text.ParserCombinators.Parsec.Token as Token
 
 > import Control.Lens
 > import Data.Data.Lens
@@ -16,9 +13,7 @@
 > import Language.Haskell.TH.Quote
 > import Language.Haskell.Meta.Parse
 
-> import Data.Maybe
-> import Debug.Trace
-> import Data.Char
+> import Data.Functor(void)
 
 > import Control.Comonad
 
@@ -39,6 +34,7 @@ core operations of the comonad
 > coextendR :: Comonad c => (c a -> b) -> c a -> c b
 > coextendR = extend
 
+> fv :: String -> ExpQ
 > fv var = varE $ mkName var
 
 > -- Codo translation comprises a (1) parsing/textual-transformation phase
@@ -51,6 +47,7 @@ core operations of the comonad
 > -- (1) Parsing/textual-transformation
 > -- *****************************
 
+> context :: QuasiQuoter
 > context = codo
 
 > codo :: QuasiQuoter
@@ -60,6 +57,7 @@ core operations of the comonad
 >                      quoteDec = undefined }
 
 
+> interpretCodo :: String -> Q Exp
 > interpretCodo s = do loc <- location
 >                      let pos = (loc_filename loc,
 >                                   fst (loc_start loc),
@@ -67,49 +65,50 @@ core operations of the comonad
 >                                      -- the start of the line
 >                      -- the following corrects the text to account for the preceding
 >                      -- Haskell code + quasiquote, to preserve alignment of further lines
->                      s'' <- return ((take (snd (loc_start loc) - 1) (repeat ' ')) ++ s)
->                      s''' <- (doParse codoTransPart pos s'')
->                      case (parseExp s''') of
+>                      let s'' = replicate (snd (loc_start loc) - 1) ' ' ++ s
+>                      s''' <- doParse codoTransPart pos s''
+>                      case parseExp s''' of
 >                             Left l -> error l
 >                             Right e -> codoMain e
 
-> doParse :: Monad m => (Parser a) -> (String, Int, Int) -> String -> m a
+> doParse :: MonadFail m => Parser a -> (String, Int, Int) -> String -> m a
 > doParse parser (file, line, col) input =
->     case (runParser p () "" input) of
+>     case runParser p () "" input of
 >          Left err  -> fail $ show err
 >          Right x   -> return x
 >          where
 >           p = do { pos <- getPosition;
 >                    setPosition $
->                     (flip setSourceName) file $
->                     (flip setSourceLine) line $
->                     (flip setSourceColumn) col $ pos;
+>                     flip setSourceName file $
+>                     flip setSourceLine line $
+>                     setSourceColumn pos col;
 >                    x <- parser;
 >                    return x; }
 
 
 > -- Parsing a codo-block
 
-> pattern  = (try ( do string "=>"
->                      return "" )) <|>
->                ( do p <- anyChar
->                     ps <- pattern
->                     return $ p:ps )
+> pattern_ :: Parser String
+> pattern_  = try ( "" <$ string "=>") <|>
+>   ((:) <$> anyChar <*> pattern_)
 
 
+
+> codoTransPart :: Parser String
 > codoTransPart = do s1 <- many space
->                    p <- pattern
->                    rest <- many (codoTransPart')
->                    return $ (take (length s1 - 4) (repeat ' '))
+>                    p <- pattern_
+>                    rest <- many codoTransPart'
+>                    return $ replicate (length s1 - 4) ' '
 >                               ++ "\\" ++ p ++ "-> do" ++ concat rest
 
-> codoTransPart' = try ( do string "codo" 
+> codoTransPart' :: Parser String
+> codoTransPart' = try ( do void $ string "codo" 
 >                           s1 <- many space
->                           p <- pattern
+>                           p <- pattern_
 >                           s3 <- many space
 >                           pos <- getPosition
->                           col <- return $ sourceColumn pos
->                           marker <- return $ ("_reserved_codo_block_marker_\n" ++ (take (col - 1) (repeat ' ')))
+>                           let col = sourceColumn pos
+>                               marker = "_reserved_codo_block_marker_\n" ++ replicate (col - 1) ' '
 >                           return $ "\\" ++ p ++ "->" ++ s1 ++ "do " ++ s3 ++ marker)
 >                  <|> ( do c <- anyChar
 >                           if c=='_' then return "_reserved_gamma_"
@@ -123,7 +122,7 @@ core operations of the comonad
 
 > -- Top-level translation
 > codoMain :: Exp -> Q Exp
-> codoMain (LamE p bs) = [| $(codoMain' (LamE p bs)) . (cmapR $(return $ projFun p)) |]
+> codoMain (LamE p bs) = [| $(codoMain' (LamE p bs)) . cmapR $(return $ projFun p) |]
 
 > codoMain' :: Exp -> Q Exp
 > codoMain' (LamE [TupP ps] (DoE stms)) = codoBind stms (concatMap patToVarPs ps)
@@ -131,6 +130,7 @@ core operations of the comonad
 > codoMain' (LamE [VarP v] (DoE stms)) = codoBind stms [v]
 > codoMain' _ = error codoPatternError
 
+> codoPatternError :: String
 > codoPatternError = "Malformed codo: codo must start with either a variable, wildcard, or tuple pattern (of wildcards or variables)"
 
 > -- create the projection function to arrange the codo-Block parameters into the correct ordder
@@ -140,14 +140,18 @@ core operations of the comonad
 > patToVarPs (VarP v)  = [v]
 > patToVarPs _         = error "Only tuple, variable, or wildcard patterns currently allowed"
 
+> projExp :: [Exp] -> Exp
 > projExp [] = TupE []
-> projExp (x:xs) = TupE [x, (projExp xs)]
+> projExp (x:xs) = TupE [x, projExp xs]
 
+> projPat :: [Pat] -> Pat
 > projPat [] = TupP []
-> projPat (x:xs) = TupP [x, (projPat xs)]
+> projPat (x:xs) = TupP [x, projPat xs]
 
+> projFun :: [Pat] -> Exp
 > projFun p = LamE (map replaceWild p) (projExp (map VarE (concatMap patToVarPs p)))
 
+> replaceWild :: Pat -> Pat
 > replaceWild WildP = VarP $ mkName "_reserved_gamma_"
 > replaceWild x = x
 
@@ -155,6 +159,7 @@ core operations of the comonad
 > -- ii). bindings transformations
 > -- **********************
 
+> convert :: [Name] -> [Name] -> Exp
 > convert lVars envVars = LamE [TupP [TupP (map VarP lVars),
 >                                     projPat (map VarP envVars)]] (projExp (map VarE (lVars ++ envVars)))
 
@@ -162,26 +167,26 @@ core operations of the comonad
 > -- Binding interpretation (\vdash_c)
 
 > codoBind :: [Stmt] -> [Name] -> Q Exp
-> codoBind [NoBindS e]             vars = [| \gamma -> $(envProj vars (transformMOf uniplate (doToCodo) e)) gamma |]
-> codoBind [x]                     vars = error "Codo block must end with an expressions"
+> codoBind [NoBindS e]             vars = [| $(envProj vars (transformMOf uniplate doToCodo e)) |]
+> codoBind [_]                     _    = error "Codo block must end with an expressions"
 > codoBind ((NoBindS e):bs)        vars = [| $(codoBind bs vars) .
 >                                               (coextendR (\gamma ->
->                                                  ($(envProj vars (transformMOf uniplate (doToCodo) e)) gamma,
+>                                                  ($(envProj vars (transformMOf uniplate doToCodo e)) gamma,
 >                                                   extract gamma))) |]
 
 > codoBind ((LetS [ValD p (NormalB e) []]):bs) vars =
 >                                           [| (\gamma ->
 >                                                  $(letE [valD (return p)
->                                                   (normalB $ [| $(envProj vars (transformMOf uniplate (doToCodo) e)) gamma |]) []] [| $(codoBind bs vars) $(fv "gamma") |])) |]
+>                                                   (normalB $ [| $(envProj vars (transformMOf uniplate doToCodo e)) gamma |]) []] [| $(codoBind bs vars) $(fv "gamma") |])) |]
 
 > codoBind ((BindS (VarP v) e):bs) vars = [| $(codoBind bs (v:vars)) .
 >                                            (coextendR (\gamma ->
->                                                       ($(envProj vars (transformMOf uniplate (doToCodo) e)) gamma,
+>                                                       ($(envProj vars (transformMOf uniplate doToCodo e)) gamma,
 >                                                        extract gamma))) |]
-> codoBind ((BindS (TupP ps) e):bs) vars = [| $(codoBind bs ((concatMap patToVarPs ps) ++ vars)) .
+> codoBind ((BindS (TupP ps) e):bs) vars = [| $(codoBind bs (concatMap patToVarPs ps ++ vars)) .
 >                                            (coextendR (\gamma ->
 >                                                      $(return $ convert (concatMap patToVarPs ps) vars)  
->                                                       ($(envProj vars (transformMOf uniplate (doToCodo) e)) gamma,
+>                                                       ($(envProj vars (transformMOf uniplate doToCodo e)) gamma,
 >                                                        extract gamma))) |]
 > codoBind t _ = error "Ill-formed codo bindings"
 
@@ -191,7 +196,7 @@ core operations of the comonad
 >              -- notably, doesn't pick up outside environment
 >              | showName n == "_reserved_codo_block_marker_" = codoMain (LamE [VarP v] (DoE stmts))
 >
->              | otherwise = return $ (DoE ((NoBindS (VarE n)):stmts))
+>              | otherwise = return $ DoE (NoBindS (VarE n):stmts)
 > doToCodo e  = return e
 
 
@@ -201,15 +206,17 @@ core operations of the comonad
 
 > -- Creates a scope where all the local variables are project
 > envProj :: [Name] -> ExpQ -> ExpQ
-> envProj vars exp = let gam = mkName "gamma" in (lamE [varP gam] (letE (projs vars (varE gam)) exp))
+> envProj vars expq = let gam = mkName "gamma" in lamE [varP gam] (letE (projs vars (varE gam)) expq)
 
 > -- Make a comonadic projection
-> mkProj gam (v, n) = valD (varP v) (normalB [| cmapR $(prj n) $(gam) |]) []
+> mkProj :: ExpQ -> Name -> Int -> DecQ
+> mkProj gam v n = valD (varP v) (normalB [| cmapR $(prj n) $(gam) |]) []
 
 > -- Creates a list of projections
 > projs :: [Name] -> ExpQ -> [DecQ]
-> projs x gam =  map (mkProj gam) (zip x [0..(length x - 1)])
+> projs x gam = zipWith (mkProj gam) x [0..(length x - 1)]
 
 > -- Computes the correct projection
+> prj :: Int -> ExpQ
 > prj 0 = [| fst |]
 > prj n = [| $(prj (n-1)) . snd |]


### PR DESCRIPTION
Due to separation between `Monad` and `MonadFail` the code no longer compiles on newer GHC versions. This PR fixes that issue and by the way gets rid of most warnings.